### PR TITLE
HDLS-175: Set default shipping on page load

### DIFF
--- a/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
+++ b/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
@@ -9,8 +9,8 @@ import LoadingState from '../LoadingState/LoadingState';
 const IndexPage = () => {
   const { state } = useCheckoutStore();
   const { order_total, customer, addresses, shipping } = state.applicationState;
-  const shippingAddressLines = addresses.shipping.address_line_2 ? `${addresses.shipping.address_line_1}, ${address.shipping.address_line_2}` : addresses.shipping.address_line_1;
-  const billingAddressLines = addresses.billing.address_line_2 ? `${addresses.billing.address_line_1}, ${address.billing.address_line_2}` : addresses.billing.address_line_1;
+  const shippingAddressLines = addresses.shipping.address_line_2 ? `${addresses.shipping.address_line_1}, ${addresses.shipping.address_line_2}` : addresses.shipping.address_line_1;
+  const billingAddressLines = addresses.billing.address_line_2 ? `${addresses.billing.address_line_1}, ${addresses.billing.address_line_2}` : addresses.billing.address_line_1;
   const { submitShippingAddress } = useShippingAddress();
   const [loading, setLoading] = useState(false);
   

--- a/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
+++ b/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
@@ -17,7 +17,7 @@ const IndexPage = () => {
   const setDefaultAddress = useCallback(async () => {
     setLoading(true);
     try {
-      await submitShippingAddress(state.applicationState.customer.saved_addresses[0]);
+      await submitShippingAddress(customer.saved_addresses[0]);
     } catch(e) {
       setLoading(false);
     }
@@ -26,7 +26,7 @@ const IndexPage = () => {
 
   useEffect(() => {
     //if customer hasn't set a shipping address yet and they have a saved shipping address, set the shipping address to the first one. 
-    if(addresses.shipping.length == 0 && state.applicationState.customer.saved_addresses.length > 0){
+    if(addresses.shipping.length == 0 && customer.saved_addresses.length > 0){
       setDefaultAddress();
     }
   }, []);

--- a/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
+++ b/one_click/client/components/OneClickLayout/components/Index/IndexPage.jsx
@@ -22,7 +22,7 @@ const IndexPage = () => {
       setLoading(false);
     }
     setLoading(false);
-  }, [state]);
+  }, [customer.saved_addresses]);
 
   useEffect(() => {
     //if customer hasn't set a shipping address yet and they have a saved shipping address, set the shipping address to the first one. 

--- a/one_click/client/components/OneClickLayout/components/LoadingState/LoadingState.css
+++ b/one_click/client/components/OneClickLayout/components/LoadingState/LoadingState.css
@@ -1,6 +1,13 @@
-.FieldSet--LoadingState {
+.FieldSet .FieldSet--LoadingState {
   border: 1px solid #d9d9d9;
   height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.FieldSet--LoadingState {
+  height:68px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
#### Overview
* Set default shipping address on initial page load if a saved address exists.

**Note:** Currently set to merge into one-click/develop instead of develop due to changes in this [PR](https://github.com/bold-commerce/checkout-react-templates/pull/22)