### PR TITLE
Handle payment iframe errors updated

### DIFF
--- a/one_click/client/components/OneClickLayout/components/CheckoutButton/CheckoutButton.jsx
+++ b/one_click/client/components/OneClickLayout/components/CheckoutButton/CheckoutButton.jsx
@@ -43,7 +43,7 @@ const CheckoutButtonContainer = ({ className }, ref) => {
   const orderErrorMessage = state.errors.order?.public_order_id;
 
   // don't disable checkout button if only error is order error
-  const hasErrors = Object.keys(state.errors).some((errorKey) => errorKey != 'order' && state.errors[errorKey] != null);
+  const hasErrors = Object.keys(state.errors).some((errorKey) => errorKey != 'order' && errorKey != 'paymentIframe' && state.errors[errorKey] != null);
   const missingAddress = Object.values(state.applicationState.addresses).some(x => x === null || x.length === 0);
   const checkoutButtonDisabled = state.loadingStatus.isLoading || hasErrors ||  missingAddress;
   const processing = orderStatus === 'processing' || orderStatus === 'authorizing';

--- a/one_click/package.json
+++ b/one_click/package.json
@@ -37,7 +37,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@boldcommerce/checkout-react-components": "^4.0.0-beta-20211122",
+    "@boldcommerce/checkout-react-components": "^4.0.2",
     "@boldcommerce/stacks-ui": "^1.2.0",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",


### PR DESCRIPTION
#### Overview
* update react-checkout-components package
* don't disable checkout button if paymentIframe error (error doesn't get cleared)